### PR TITLE
Dense and sparse version for FiedlerVector computation

### DIFF
--- a/pyTempNet/Measures.py
+++ b/pyTempNet/Measures.py
@@ -17,7 +17,7 @@ import matplotlib.pylab as plt
 from pyTempNet import Utilities
 
 def Laplacian(temporalnet, model="SECOND"):
-    """Returns the Laplacian matrix corresponding to the the second-order (model=SECOND) or 
+    """Returns the transposed Laplacian matrix corresponding to the the second-order (model=SECOND) or 
     the second-order null (model=NULL) model for a temporal network.
     
     @param temporalnet: The temporalnetwork instance to work on
@@ -38,16 +38,22 @@ def Laplacian(temporalnet, model="SECOND"):
     return I-T2
 
 
-def FiedlerVector(temporalnet, model="SECOND", normalize=True):
+def FiedlerVectorSparse(temporalnet, model="SECOND", normalize=True):
     """Returns the Fiedler vector of the second-order (model=SECOND) or the
     second-order null (model=NULL) model for a temporal network. The Fiedler 
-     vector can be used for a spectral bisectioning of the network.
+    vector can be used for a spectral bisectioning of the network.
+     
+    Note that sparse linear algebra for eigenvalue problems with small eigenvalues 
+    is problematic in terms of numerical stability. Consider using the dense version
+    of this measure.
      
     @param temporalnet: The temporalnetwork instance to work on
     @param model: either C{"SECOND"} or C{"NULL"}, where C{"SECOND"} is the 
       the default value.
+    @param normalize: whether (default) or not to normalize the fiedler vector.
+      Normalization is done such that the sum of squares equals one in order to
+      get reasonable values as entries might be positive and negative.
     """
-    start = tm.clock()
     if (model is "SECOND" or "NULL") == False:
         raise ValueError("model must be one of \"SECOND\" or \"NULL\"")
     
@@ -57,48 +63,25 @@ def FiedlerVector(temporalnet, model="SECOND", normalize=True):
     # NOTE: in order to be more confident to find the one with the largest
     # NOTE: magnitude, see
     # NOTE: https://github.com/scipy/scipy/issues/4987
-    #w, v = sla.eigs( L, k=2, which="SM", ncv=13 )
-    #w, v = sla.eigs( L, k=2, sigma=0, ncv=13, which="LM", maxiter=20*L.get_shape()[0])
     w = sla.eigs( L, k=2, which="SM", ncv=13, return_eigenvectors=False )
-    print(      "w=", np.sort(np.absolute(w)))
     
-    ew = tm.clock()
-    #print("     time for laplacian and eigs()", (ew - start))
-    
-    # compute sparse LU decomposition of the laplacian
+    # compute a sparse LU decomposition and solve for the eigenvector 
+    # corresponding to the second largest eigenvalue
     n = L.get_shape()[0]
     b = np.ones(n)
     evalue = np.sort(np.abs(w))[1]
     A = (L[1:n,:].tocsc()[:,1:n] - sparse.identity(n-1).multiply(evalue))
     b[1:n] = A[0,:].toarray()
     
-    ab = tm.clock()
-    #print("     getting A and b ready", (ab - ew))
-    
-    ## have a look at the sparsity pattern of the matrix
-    #plt.spy(A, markersize=1)
-    #plt.show()
-    
-    #print b.shape
-    #print A.shape
     lu = sla.splu(A)
-    #print lu.solve(b[1:n]).shape
     b[1:n] = lu.solve(b[1:n])
-    #v = b/sum(np.inner(b,b))
-    #print(sum(b))
-    #print("     solving the system", (tm.clock() - ab))
-    #print("Time spent in FiedlerVector():", (tm.clock() - start))
-    #print(v[0:5], sum(v))
+
     if normalize:
         b /= np.sqrt(np.inner(b, b))
     return b
-    
-    # TODO: ask, if this vector should be normalized. Sparse Linalg sometimes
-    # TODO: finds the EV scaled factor (-1)
-    #return v[:,np.argsort(np.absolute(w))][:,1]
 
 
-def DenseFiedlerVector(temporalnet, model="SECOND"):
+def FiedlerVectorDense(temporalnet, model="SECOND"):
     """Returns the Fiedler vector of the second-order (model=SECOND) or the
     second-order null (model=NULL) model for a temporal network. The Fiedler 
      vector can be used for a spectral bisectioning of the network.
@@ -107,52 +90,16 @@ def DenseFiedlerVector(temporalnet, model="SECOND"):
     @param model: either C{"SECOND"} or C{"NULL"}, where C{"SECOND"} is the 
       the default value.
     """
-    start = tm.clock()
     if (model is "SECOND" or "NULL") == False:
         raise ValueError("model must be one of \"SECOND\" or \"NULL\"")
     
-    # NOTE: The transposed matrix is needed to get the "left" eigen vectors
+    # NOTE: The Laplacian is transposed for the sparse case to get the left
+    # NOTE: eigenvalue.
     L = Laplacian(temporalnet, model)
-    # NOTE: ncv=13 sets additional auxiliary eigenvectors that are computed
-    # NOTE: in order to be more confident to find the one with the largest
-    # NOTE: magnitude, see
-    # NOTE: https://github.com/scipy/scipy/issues/4987
-    #w, v = sla.eigs( L, k=2, which="SM", ncv=13 )
-    #w, v = sla.eigs( L, k=2, sigma=0, ncv=13, which="LM", maxiter=20*L.get_shape()[0])
+    # convert to dense matrix and transpose again to have the untransposed
+    # laplacian again.
     w, v = la.eig(L.todense().transpose(), right=False, left=True)
-    print("     w=", np.sort(np.absolute(w))[0:2])
-    #w = sla.eigs( L, k=2, which="SM", ncv=13, return_eigenvectors=False )
-    
-    
-    ew = tm.clock()
-    #print("     time for laplacian and eigs()", (ew - start))
-    
-    ## compute sparse LU decomposition of the laplacian
-    #n = L.get_shape()[0]
-    #b = np.ones(n)
-    #evalue = np.sort(np.abs(w))[1]
-    #A = (L[1:n,:].tocsc()[:,1:n] - sparse.identity(n-1).multiply(evalue))
-    #b[1:n] = A[0,:].toarray()
-    
-    #ab = tm.clock()
-    #print("     getting A and b ready", (ab - ew))
-    
-    ##print b.shape
-    ##print A.shape
-    #lu = sla.splu(A)
-    ##print lu.solve(b[1:n]).shape
-    #b[1:n] = lu.solve(b[1:n])
-    #v = b/sum(b)
-    #print("     solving the system", (tm.clock() - ab))
-    #ret = v[:,np.argsort(np.absolute(w))][:,1]
-    #print(sum(ret))
-    #ret = ret/sum(ret)
-    print("Time spent in DenseFiedlerVector():", (tm.clock() - start))
-    #return v
-    
-    # TODO: ask, if this vector should be normalized. Sparse Linalg sometimes
-    # TODO: finds the EV scaled factor (-1)
-    #print(v[:,np.argsort(np.absolute(w))][0:5,1], sum(v[:,np.argsort(np.absolute(w))][:,1]))
+
     return v[:,np.argsort(np.absolute(w))][:,1]
 
 def AlgebraicConn(temporalnet, model="SECOND"):

--- a/pyTempNet/Measures.py
+++ b/pyTempNet/Measures.py
@@ -79,12 +79,12 @@ def FiedlerVector(temporalnet, model="SECOND"):
     lu = sla.splu(A)
     #print lu.solve(b[1:n]).shape
     b[1:n] = lu.solve(b[1:n])
-    v = b/sum(b)
+    #v = b/sum(np.inner(b,b))
     #print(sum(b))
     print("     solving the system", (tm.clock() - ab))
     print("Time spent in FiedlerVector():", (tm.clock() - start))
-    print(v[0:5], sum(v))
-    return v
+    #print(v[0:5], sum(v))
+    return b
     
     # TODO: ask, if this vector should be normalized. Sparse Linalg sometimes
     # TODO: finds the EV scaled factor (-1)
@@ -145,7 +145,7 @@ def DenseFiedlerVector(temporalnet, model="SECOND"):
     
     # TODO: ask, if this vector should be normalized. Sparse Linalg sometimes
     # TODO: finds the EV scaled factor (-1)
-    print(v[:,np.argsort(np.absolute(w))][0:5,1], sum(v[:,np.argsort(np.absolute(w))][:,1]))
+    #print(v[:,np.argsort(np.absolute(w))][0:5,1], sum(v[:,np.argsort(np.absolute(w))][:,1]))
     return v[:,np.argsort(np.absolute(w))][:,1]
 
 def AlgebraicConn(temporalnet, model="SECOND"):

--- a/pyTempNet/Measures.py
+++ b/pyTempNet/Measures.py
@@ -12,6 +12,7 @@ import scipy.sparse.linalg as sla
 import scipy.linalg as la
 
 import time as tm
+import matplotlib.pylab as plt
 
 from pyTempNet import Utilities
 
@@ -37,7 +38,7 @@ def Laplacian(temporalnet, model="SECOND"):
     return I-T2
 
 
-def FiedlerVector(temporalnet, model="SECOND"):
+def FiedlerVector(temporalnet, model="SECOND", normalize=True):
     """Returns the Fiedler vector of the second-order (model=SECOND) or the
     second-order null (model=NULL) model for a temporal network. The Fiedler 
      vector can be used for a spectral bisectioning of the network.
@@ -62,7 +63,7 @@ def FiedlerVector(temporalnet, model="SECOND"):
     print(      "w=", np.sort(np.absolute(w)))
     
     ew = tm.clock()
-    print("     time for laplacian and eigs()", (ew - start))
+    #print("     time for laplacian and eigs()", (ew - start))
     
     # compute sparse LU decomposition of the laplacian
     n = L.get_shape()[0]
@@ -72,7 +73,11 @@ def FiedlerVector(temporalnet, model="SECOND"):
     b[1:n] = A[0,:].toarray()
     
     ab = tm.clock()
-    print("     getting A and b ready", (ab - ew))
+    #print("     getting A and b ready", (ab - ew))
+    
+    ## have a look at the sparsity pattern of the matrix
+    #plt.spy(A, markersize=1)
+    #plt.show()
     
     #print b.shape
     #print A.shape
@@ -81,9 +86,11 @@ def FiedlerVector(temporalnet, model="SECOND"):
     b[1:n] = lu.solve(b[1:n])
     #v = b/sum(np.inner(b,b))
     #print(sum(b))
-    print("     solving the system", (tm.clock() - ab))
-    print("Time spent in FiedlerVector():", (tm.clock() - start))
+    #print("     solving the system", (tm.clock() - ab))
+    #print("Time spent in FiedlerVector():", (tm.clock() - start))
     #print(v[0:5], sum(v))
+    if normalize:
+        b /= np.sqrt(np.inner(b, b))
     return b
     
     # TODO: ask, if this vector should be normalized. Sparse Linalg sometimes
@@ -115,10 +122,10 @@ def DenseFiedlerVector(temporalnet, model="SECOND"):
     w, v = la.eig(L.todense().transpose(), right=False, left=True)
     print("     w=", np.sort(np.absolute(w))[0:2])
     #w = sla.eigs( L, k=2, which="SM", ncv=13, return_eigenvectors=False )
-    #print np.sort(np.absolute(w))
+    
     
     ew = tm.clock()
-    print("     time for laplacian and eigs()", (ew - start))
+    #print("     time for laplacian and eigs()", (ew - start))
     
     ## compute sparse LU decomposition of the laplacian
     #n = L.get_shape()[0]

--- a/pyTempNet/Measures.py
+++ b/pyTempNet/Measures.py
@@ -53,6 +53,13 @@ def FiedlerVector(temporalnet, model="SECOND"):
     # NOTE: magnitude, see
     # NOTE: https://github.com/scipy/scipy/issues/4987
     w, v = sla.eigs( L, k=2, which="SM", ncv=13 )
+    #w, v = sla.eigs( L, k=2, sigma=0, ncv=13, which="LM", maxiter=20*L.get_shape()[0])
+    #w = sla.eigs( L, k=2, which="SM", ncv=13, return_eigenvectors=False )
+    #print np.sort(np.absolute(w))
+    
+    #v = np.empty(L.get_shape()[0])
+    #v[0] = 1
+    #v[1:len(v)] = 
     
     # TODO: ask, if this vector should be normalized. Sparse Linalg sometimes
     # TODO: finds the EV scaled factor (-1)

--- a/pyTempNet/Measures.py
+++ b/pyTempNet/Measures.py
@@ -11,9 +11,6 @@ import scipy.sparse as sparse
 import scipy.sparse.linalg as sla
 import scipy.linalg as la
 
-import time as tm
-import matplotlib.pylab as plt
-
 from pyTempNet import Utilities
 
 def Laplacian(temporalnet, model="SECOND"):
@@ -45,7 +42,8 @@ def FiedlerVectorSparse(temporalnet, model="SECOND", normalize=True):
      
     Note that sparse linear algebra for eigenvalue problems with small eigenvalues 
     is problematic in terms of numerical stability. Consider using the dense version
-    of this measure.
+    of this measure. Note also that the FiedlerVector might be scaled by a factor (-1)
+    compared to the dense version.
      
     @param temporalnet: The temporalnetwork instance to work on
     @param model: either C{"SECOND"} or C{"NULL"}, where C{"SECOND"} is the 

--- a/pyTempNet/Utilities.py
+++ b/pyTempNet/Utilities.py
@@ -137,7 +137,7 @@ def getSparseAdjacencyMatrix( graph, attribute=None, transposed=False ):
             row.append(s)
             col.append(t)
       data = np.array(graph.es()[attribute])
-          
+
     return sparse.coo_matrix((data, (row, col)) , shape=(len(graph.vs), len(graph.vs))).tocsr()
 
 
@@ -146,7 +146,6 @@ def RWTransitionMatrix(g):
     and directed network
     
     @param g: the graph"""
-    
     row = []
     col = []
     data = []

--- a/pyTempNet/Utilities.py
+++ b/pyTempNet/Utilities.py
@@ -142,7 +142,7 @@ def getSparseAdjacencyMatrix( graph, attribute=None, transposed=False ):
 
 
 def RWTransitionMatrix(g):
-    """Generates a random walk transition matrix corresponding to a (possibly) weighted
+    """Generates a transposed random walk transition matrix corresponding to a (possibly) weighted
     and directed network
     
     @param g: the graph"""


### PR DESCRIPTION
FiedlerVector computation relies on finding the eigenvector corresponding to the second smallest eigenvalue. Eigenvalue problems are numerically unstable for small Eigenvalues. Thus, in addition to the sparse linalg version of Fiedler vector computation, a second version using dense linear algebra is added. 
